### PR TITLE
Fix #61: Homepage - Stats integer

### DIFF
--- a/database/migrations/2026_04_10_update_airports_table_stats_integer.php
+++ b/database/migrations/2026_04_10_update_airports_table_stats_integer.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('airports', function (Blueprint $table) {
+            $table->integer('stats_ground')->nullable()->change();
+            $table->integer('stats_inbound')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('airports', function (Blueprint $table) {
+            $table->dropColumn(['stats_ground']);
+            $table->dropColumn(['stats_inbound']);
+        });
+    }
+};


### PR DESCRIPTION
## Description

`ParialsController::updateAirportStats()` [orders](https://github.com/JoshuaMicallefYBSU/OzBays/blob/c32641eb9f5e0a53e7c5be7c548023834cc013c8/app/Http/Controllers/PartialsController.php#L43) `Airport`s by `stats_ground` and `stats_inbound`. These columns are strings, which causes the undesired sorting behaviour.

I've never touched Laravel before, so I can only suppose that these values being [treated like integers](https://github.com/JoshuaMicallefYBSU/OzBays/blob/c32641eb9f5e0a53e7c5be7c548023834cc013c8/app/Jobs/FlightData.php#L225) and behaving (mostly) as expected would have caused this to go unnoticed.

## Changes

Make both `stats_ground` and `stats_inbound` integer columns.